### PR TITLE
Add support for responding to enquire_link  from SMSC

### DIFF
--- a/src/esmpp_pdu.erl
+++ b/src/esmpp_pdu.erl
@@ -7,6 +7,7 @@
 -export([
   bind/2,
   enquire_link/1,
+  enquire_link_resp/1,
   submit_sm/2,
   deliver_sm_resp/1,
   unbind/1
@@ -22,6 +23,7 @@
 -include("constants.hrl").
 -include("types.hrl").
 -include("commands.hrl").
+-include("command_statuses.hrl").
 
 %% @doc Encode a bind PDU from a sequence number and a bind_pdu record
 -spec bind(integer(), bind_pdu()) -> {pdu, binary()}.
@@ -50,6 +52,17 @@ enquire_link(SeqNumInt) ->
   Status     = pad4(binary:encode_unsigned(?NULL)),
   SeqNum     = pad4(binary:encode_unsigned(SeqNumInt)),
   Command    = pad4(binary:encode_unsigned(?ENQUIRE_LINK)),
+  TmpPDU     = <<Command/binary, Status/binary, SeqNum/binary>>,
+  Length     = pad4(binary:encode_unsigned(size(TmpPDU) + 4)),
+  PDU        = <<Length/binary, TmpPDU/binary>>,
+  {pdu, PDU}.
+
+%% @doc Encode an enquire_link_resp PDU from a sequence number
+-spec enquire_link_resp(integer()) -> {pdu, binary()}.
+enquire_link_resp(SeqNumInt) ->
+  Status     = pad4(binary:encode_unsigned(?ESME_ROK)),
+  SeqNum     = pad4(binary:encode_unsigned(SeqNumInt)),
+  Command    = pad4(binary:encode_unsigned(?ENQUIRE_LINK_RESP)),
   TmpPDU     = <<Command/binary, Status/binary, SeqNum/binary>>,
   Length     = pad4(binary:encode_unsigned(size(TmpPDU) + 4)),
   PDU        = <<Length/binary, TmpPDU/binary>>,

--- a/src/esmpp_worker.erl
+++ b/src/esmpp_worker.erl
@@ -404,6 +404,25 @@ handle_info({tcp, _Socket, <<_Len:32, ?ENQUIRE_LINK_RESP:32, ?ESME_ROK:32,
   {noreply, State};
 
 %% ----------------------------------------------------------------------------
+%% @private Handle an incomming enquire_link when in bound state
+%% ----------------------------------------------------------------------------
+handle_info({tcp, _Socket, <<_Len:32, ?ENQUIRE_LINK:32, _Null:32,
+                             Seq:32, _Data/binary>>}, #state{connected=true, socket=Socket} = State) ->
+  {pdu,    Packet} = esmpp_pdu:enquire_link_resp(Seq),
+  send(Socket, Packet),
+  {noreply, State};
+
+%% ----------------------------------------------------------------------------
+%% @private Handle an incomming enquire_link when in Unbound state
+%% ----------------------------------------------------------------------------
+handle_info({tcp, _Socket, <<_Len:32, ?ENQUIRE_LINK:32, _Null:32,
+                             Seq:32, _Data/binary>>}, #state{connected=false} = State) ->
+   io:format(standard_error, "[~p] Received EQUIRE_LINK(UNBOUND STATE) Seq : ~p", [
+    ?MODULE, Seq
+  ]),
+  {noreply, State};
+
+%% ----------------------------------------------------------------------------
 %% @private Connection closed from unbind
 %% ----------------------------------------------------------------------------
 handle_info({tcp_closed, _Socket}, #state{connected=false, tref=TRef} = State) ->


### PR DESCRIPTION
 **Feature Summary**
- Add  support for responding to an incoming enquire_link PDU. 
- In bound state, an **enquire_link response** is sent immediately 
- In unbound state a log message is generated and state is not altered  

**Code Change Summary**
- Add enquire_link_resp pdu in **esmpp_pdu** 
- Add handler for enquire_link (bound and unbound state) in **esmpp_worker** 
